### PR TITLE
Added `/conferences` and `/conferences/<confId>` routes

### DIFF
--- a/src/Model.hs
+++ b/src/Model.hs
@@ -35,10 +35,12 @@ Password sql=passwords
 
 Account sql=accounts
   owner OwnerId
+  UniqueAccountOwnerId owner
   deriving Eq Show
 
 Owner sql=owners
   user UserId
+  UniqueOwnerUserId user
   deriving Eq Show
 
 Admin sql=admins

--- a/src/Model/API.hs
+++ b/src/Model/API.hs
@@ -14,6 +14,17 @@ import Model as Export
 getOwnerForUser :: UserId -> DB (Maybe (Entity Owner))
 getOwnerForUser userId = getRecByField OwnerUser userId
 
+getAccountForOwner :: OwnerId -> DB (Maybe (Entity Account))
+getAccountForOwner ownerId = getRecByField AccountOwner ownerId
+
+getAccountForUser :: UserId -> DB (Maybe (Entity Account))
+getAccountForUser userId = do
+  mOwner <- getOwnerForUser userId
+  case mOwner of
+    Nothing -> pure Nothing
+    Just owner -> getAccountForOwner (entityKey owner)
+
+
 getRecsByField' :: ( DBAll val typ backend
                   , MonadIO m
                  )
@@ -162,3 +173,9 @@ createAccount email pass = do
 createConferenceForAccount :: AccountId -> Text -> Text -> DB (Entity Conference)
 createConferenceForAccount accountId confName confDesc = do
   insertEntity $ Conference accountId confName confDesc
+
+getConferencesByAccount :: AccountId -> DB [Entity Conference]
+getConferencesByAccount accId = getRecsByField ConferenceAccount accId
+
+getConference :: ConferenceId -> DB (Maybe (Entity Conference))
+getConference confId = getRecByField ConferenceId confId

--- a/src/Model/Fixtures.hs
+++ b/src/Model/Fixtures.hs
@@ -69,9 +69,15 @@ insertFixtures = do
   -- let chris = unsafeIdx allUsersF 0
   --     alexey = unsafeIdx allUsersF 1
   let chrisAccount = unsafeIdx allAccountsF 0
-  allConferencesF <-
-    traverse (makeConference (entityKey chrisAccount)) ["ChrisConf"]
-  let userF = UserFixtures {..}
+      alexeyAccount = unsafeIdx allAccountsF 1
+  chrisConferencesF <- do
+    traverse (makeConference (entityKey chrisAccount))
+      ["Chris Conf 9000", "Chris's Other Conf", "Chris's Best Conf" ]
+  alexeyConferencesF <- do
+    traverse (makeConference (entityKey alexeyAccount))
+      ["Alexey Conf 9000", "Alexey's Other Conf", "Alexeys's Best Conf" ]
+  let allConferencesF = chrisConferencesF ++ alexeyConferencesF
+      userF = UserFixtures {..}
       ownerF = OwnerFixtures {..}
       accountF = AccountFixtures {..}
       conferenceF = ConferenceFixtures {..}


### PR DESCRIPTION
This tackles issues #28 and #29, accomplishing the following:
- Adds `getConferencesR` handler corresponding to the `/conferences` route
- Adds `getConferenceDashboardR` handler corresponding to the `/conference/#Int64` route
- Adds a unique constraint on the `UserId` of the `Owner` type
- Adds a unique constraint on the `OwnerId` of the `Account` type
- Logs warnings when `require<User/Owner/Account>` authentication check fails
- Adds helper functions for querying conferences by `UserId` or `ConferenceId`
- Adds new conference fixtures for testing purposes

I welcome code review, and requested changes!