### PR TITLE
Cfp dashboard

### DIFF
--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -134,7 +134,7 @@ getConferenceDashboardR confId = do
     <h2>
       <a href=@{ConferenceCallForProposalsR confId}>
         Call For Proposals
-    <h1>
+    <h2>
       <a href="@{ConferenceAbstractTypesR confId}">
         Abstract types
 |]
@@ -164,26 +164,29 @@ getConferenceCallForProposalsR confId = do
     setTitle "Call for Proposals"
     [whamlet|
 <article .grid-container>
-  <div .medium-12 .cell>
-    <h1>#{length abstracts} Abstract Submissions
-  $forall abstractAndType <- abstracts
-    <div .medium-12 .cell>
-      ^{renderAbstractRow abstractAndType}
+  <div .row>
+    <div .medium-12 .column>
+      <h1>#{length abstracts} Abstract Submissions
+  <div .row>
+    $forall abstractAndType <- abstracts
+      <div .medium-12 .column>
+        ^{renderAbstractRow abstractAndType}
 |]
 
 renderAbstractRow :: (Entity Abstract, Entity AbstractType) -> Widget
 renderAbstractRow (abstract, abstractType) =
   [whamlet|
-<div .medium-2 .cell>
-  <h3>title
-<div .medium-4 .cell>
-  <h3>#{name}
-  <p>#{renderTalkDuration duration}
-<div .medium-6 .cell>
-  <p>#{contentPreview}
+<div .row>
+  <div .medium-12>
+    <h3>#{title}
+  <div .row>
+    <div .medium-4 .column>
+      <h4> #{name} | #{renderTalkDuration duration}
+    <div .medium-8 .column>
+      <p>#{contentPreview}
 |]
   where
-    Abstract user _ title authorAbs meditedAbs = entityVal abstract
+    Abstract user title _ authorAbs meditedAbs = entityVal abstract
     AbstractType _ name duration = entityVal abstractType
 
     contentPreview = take 100 (fromMaybe authorAbs meditedAbs) <> "..."

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -78,10 +78,6 @@ renderConferenceAbstractTypes conferenceId abstractTypes abstractTypeFormWidget 
           <li>#{renderAbstractType (entityVal abstractType)}
     |]
 
-getAbstractTypes :: ConferenceId -> DB [Entity AbstractType]
-getAbstractTypes conferenceId =
-  getRecsByField AbstractTypeConference conferenceId
-
 getConferenceAbstractTypesR :: Int64 -> Handler Html
 getConferenceAbstractTypesR conferenceId = do
   (user, owner, account, conference) <-
@@ -105,7 +101,7 @@ postConferenceAbstractTypesR conferenceId = do
 
 getConferencesR :: Handler Html
 getConferencesR = do
-  (user, owner, account) <- requireAccount
+  (user, account) <- requireAccount
   conferences <- runDB $ getConferencesByAccount (entityKey account)
   baseLayout Nothing $ do
     setTitle "My Conferences"
@@ -122,21 +118,14 @@ getConferencesR = do
         ^{renderConferenceWidget conf}
 |]
 
+--------------------------------------------------------------------------------
+-- Conference Dashboard View
+--------------------------------------------------------------------------------
+
 getConferenceDashboardR :: Int64 -> Handler Html
 getConferenceDashboardR confId = do
-  (_, _, confAcc) <- requireAccount
-  (Conference _ name desc) <- do
-    mConference <- runDB $ fmap entityVal <$> getConference (toSqlKey confId)
-    case mConference of
-      Nothing -> do
-        $logWarn "No conference with the specified Id"
-        notFound
-      Just conf
-        | conferenceAccount conf == entityKey confAcc -> pure conf
-        | otherwise -> do
-            let errMsg = "Current account of user is not the owner of this conference"
-            $logWarn errMsg
-            permissionDenied errMsg
+  (_, confEntity) <- requireAdminForConference (toSqlKey confId)
+  let (Conference _ name desc) = entityVal confEntity
   baseLayout Nothing $ do
     setTitle (fromString (unpack name))
     [whamlet|
@@ -146,11 +135,9 @@ getConferenceDashboardR confId = do
   <div .medium-12 .cell>
     <p>#{desc}
   <div .medium-12 .cell>
-    <h1><b>PLACEHOLDER
+    <a href=@{ConferenceCallForProposalsR confId}>
+      <h2>Call For Proposals
 |]
-
-renderConferenceDashboardWidget :: Conference -> Widget
-renderConferenceDashboardWidget conf = undefined
 
 renderConferenceWidget :: Entity Conference -> Widget
 renderConferenceWidget confEntity =
@@ -163,3 +150,38 @@ renderConferenceWidget confEntity =
   where
     confId = fromSqlKey (entityKey confEntity)
     Conference _ name desc = entityVal confEntity
+
+--------------------------------------------------------------------------------
+-- CFP View
+--------------------------------------------------------------------------------
+
+getConferenceCallForProposalsR :: Int64 -> Handler Html
+getConferenceCallForProposalsR confId = do
+  (_, confEntity) <- requireAdminForConference (toSqlKey confId)
+  abstracts <- runDB (getAbstractsForConference (toSqlKey confId))
+  baseLayout Nothing $ do
+    setTitle "Call for Proposals"
+    [whamlet|
+<article .grid-container>
+  <div .medium-12 .cell>
+    <h1>#{length abstracts} Abstract Submissions
+  $forall abstractAndType <- abstracts
+    ^{renderAbstractRow abstractAndType}
+|]
+
+renderAbstractRow :: (Entity Abstract, Entity AbstractType) -> Widget
+renderAbstractRow (abstract, abstractType) = [whamlet|
+<div .medium-12 .cell>
+  <div .medium-2 .cell>
+    <h3>#{title}
+  <div .medium-4 .cell>
+    <h3>#{name}
+    <p>renderTalkDuration duration
+  <div .medium-6 .cell>
+    <p>contentPreview
+|]
+  where
+    Abstract user _ title authorAbs meditedAbs = entityVal abstract
+    AbstractType _ name duration = entityVal abstractType
+
+    contentPreview = take 100 (fromMaybe authorAbs meditedAbs) <> "..."

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -35,22 +35,24 @@ Password sql=passwords
 
 Account sql=accounts
   owner OwnerId
-  UniqueAccountOwnerId owner
+  UniqueAccountOwner owner
   deriving Eq Show
 
 Owner sql=owners
   user UserId
-  UniqueOwnerUserId user
+  UniqueOwnerUser user
   deriving Eq Show
 
 Admin sql=admins
-  account AccountId
   user UserId
+  conference ConferenceId
+  UniqueAdminUserConference user conference
   deriving Eq Show
 
 Editor sql=editors
-  account AccountId
   user UserId
+  conference ConferenceId
+  UniqueEditorUserConference user conference
   deriving Eq Show
 
 Conference sql=conferences
@@ -94,14 +96,18 @@ AbstractType sql=abstract_types
   conference ConferenceId
   name Text
   duration TalkDuration
+  UniqueAbstractConference conference
   deriving Eq Show
 
 Abstract sql=abstracts
   user UserId
+  abstractType AbstractTypeId
   title Text
   authorAbstract Text
   editedAbstract Text Maybe
+  UniqueAbstractAbstractType abstractType
   deriving Eq Show
+
 |]
 
 dumpMigration :: DB ()

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -85,7 +85,7 @@ AbstractType sql=abstract_types
   conference ConferenceId
   name Text
   duration TalkDuration
-  UniqueAbstractConference conference
+  UniqueAbstractConferenceName conference name
   deriving Eq Show
 
 Abstract sql=abstracts

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -94,7 +94,6 @@ Abstract sql=abstracts
   abstractType AbstractTypeId
   authorAbstract Text
   editedAbstract Text Maybe
-  UniqueAbstractAbstractType abstractType
   deriving Eq Show
 
 |]

--- a/src/Model/Fixtures.hs
+++ b/src/Model/Fixtures.hs
@@ -98,13 +98,11 @@ makeAbstractType abstractTypeConference
                  abstractTypeName =
   insertEntity AbstractType{..}
 
-makeAbstract :: ConferenceId
-             -> UserId
+makeAbstract :: UserId
              -> AbstractTypeId
              -> Text
              -> DB (Entity Abstract)
-makeAbstract abstractConference abstractUser
-             abstractAbstractType abstractTitle = do
+makeAbstract abstractUser abstractAbstractType abstractTitle = do
   let abstractAuthorAbstract = "my abstract body"
       abstractEditedAbstract = Nothing
   insertEntity Abstract{..}
@@ -141,18 +139,22 @@ insertFixtures = do
 
   let goldilocksAbstractType = unsafeIdx allAbstractTypesF 0
       goldilocksAbstractTypeK = entityKey goldilocksAbstractType
-      -- crispAbstractType = unsafeIdx allAbstractTypesF 1
-      -- crispAbstractTypeK = entityKey crispAbstractType
+      crispAbstractType = unsafeIdx allAbstractTypesF 1
+      crispAbstractTypeK = entityKey crispAbstractType
       theThingAbstractType = unsafeIdx allAbstractTypesF 2
       theThingAbstractTypeK = entityKey theThingAbstractType
 
   allAbstractsF <-
-    traverse (uncurry $ makeAbstract chrisFirstConfK waddlesUserK)
+    traverse (uncurry $ makeAbstract waddlesUserK)
       [ ( theThingAbstractTypeK
         , "zygohistomorphic prepromorphisms and their malcontents"
         )
+      , ( crispAbstractTypeK
+        , "crispy potato chips and their manifold destiny"
+        )
       , ( goldilocksAbstractTypeK
-        , "Bananas, Lenses and Barbreh Strysend" )
+        , "Bananas, Lenses and Barbreh Strysend"
+        )
       ]
 
   let allConferencesF = chrisConferencesF ++ alexeyConferencesF

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -22,6 +22,7 @@ mkYesodData "App" [parseRoutes|
 /conferences                      ConferencesR GET
 /conference/#Int64                ConferenceDashboardR GET
 /conference/#Int64/abstract-types ConferenceAbstractTypesR GET POST
+/conference/#Int64/cfp            ConferenceCallForProposalsR GET
 
 /cfp/submit SubmitAbstractR GET POST
 |]


### PR DESCRIPTION
This PR accomplishes #13 

- [x] Adds CFP dashboard route `/conference/#Int64/cfp`, reachable by conference `Admin/Owner` only
- [x] Displays number of submitted abstracts and their details in table 

Notes:
- There are some merge conflict resolution artifacts (i did my best)
- All previously functionality tested