### PR TITLE
Conferences dashboard now useful for everyone

### DIFF
--- a/src/Model/API.hs
+++ b/src/Model/API.hs
@@ -230,6 +230,20 @@ createConferenceForAccount accountId confName confDesc openingTime closingTime =
 getConferencesByAccount :: AccountId -> DB [Entity Conference]
 getConferencesByAccount accId = getRecsByField ConferenceAccount accId
 
+getConferencesBySubmissions :: UserId
+                            -> DB [( Entity Conference
+                                   , Entity AbstractType
+                                   , Entity Abstract
+                                   )
+                                  ]
+getConferencesBySubmissions userId =
+  select $
+    from $ \(conference `InnerJoin` abstractType `InnerJoin` abstract) -> do
+      on (abstractType ^. AbstractTypeId ==. abstract ^. AbstractAbstractType)
+      on (conference ^. ConferenceId ==. abstractType ^. AbstractTypeConference)
+      where_ (abstract ^. AbstractUser ==. val userId)
+      pure (conference, abstractType, abstract)
+
 getConference :: ConferenceId -> DB (Maybe (Entity Conference))
 getConference confId = getRecByField ConferenceId confId
 

--- a/src/Model/Fixtures.hs
+++ b/src/Model/Fixtures.hs
@@ -55,6 +55,11 @@ waddlestonEmail = [email|waddleston@lol.com|]
 waddlestonPassword :: Text
 waddlestonPassword = "waddlesPass"
 
+doNothingEmail :: Email
+doNothingEmail = [email|nothing@lol.com|]
+doNothingPassword :: Text
+doNothingPassword = "nothingPass"
+
 makeAccount :: Email -> Text -> DB (Entity User, Entity Owner, Entity Account)
 makeAccount email' pass = do
   createAccount email' pass
@@ -72,7 +77,9 @@ makeUser email' pass = do
 
 makeUsers :: DB [Entity User]
 makeUsers =
-  sequenceA [ makeUser waddlestonEmail waddlestonPassword ]
+  sequenceA [ makeUser waddlestonEmail waddlestonPassword
+            , makeUser doNothingEmail doNothingPassword
+            ]
 
 {-# INLINABLE unsafeIdx #-}
 unsafeIdx :: (MonoFoldable c) => c -> Integer -> Element c


### PR DESCRIPTION
Fixes #57 

The `/conferences` route will now render two separate sections, one for conferences you've submitted to, one for conferences you're managing.

I'll need to figure out better word than "managing" for people who aren't owner or admin (editor and abstract rater comes to mind).

This person below has no submitted abstracts or conferences managed:

![screenshot from 2018-08-19 17-20-37](https://user-images.githubusercontent.com/320177/44313819-b29fa000-a3d4-11e8-8dfc-837696c84489.png)

This is an account managing a conference but with no abstract submissions:

![screenshot from 2018-08-19 17-20-46](https://user-images.githubusercontent.com/320177/44313824-bdf2cb80-a3d4-11e8-9acf-7732df3189dd.png)

Abstract submissions, but no conferences managed:

![screenshot from 2018-08-19 17-20-58](https://user-images.githubusercontent.com/320177/44313828-c64b0680-a3d4-11e8-856f-5c861dcc821c.png)
