### PR TITLE
issue 52 - working proof of concept

### DIFF
--- a/src/Handler/Abstract.hs
+++ b/src/Handler/Abstract.hs
@@ -237,6 +237,7 @@ postSubmitAbstractR confId = do
 
 getSubmittedAbstractR :: ConferenceId -> Handler Html
 getSubmittedAbstractR confId = do
+  -- 404 no longer needed with getSubmittedAbstractPocR 
   _ <- runDBOr404 $ get confId
   baseLayout Nothing $ [whamlet|
 <article .grid-container>
@@ -246,3 +247,9 @@ getSubmittedAbstractR confId = do
       <p>
         Would you like to <a href="@{SubmitAbstractR confId}">submit another?</a>
 |]
+
+-------------------------------------------------------
+-- Proof of concept slug versions
+-------------------------------------------------------
+getSubmittedAbstractPocR :: ConferenceCode -> Handler Html
+getSubmittedAbstractPocR = withConferenceCodeRedirect SubmittedAbstractPocR getSubmittedAbstractR

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -631,3 +631,17 @@ postConferenceAbstractR confId abstractId = do
         (Entity confId conference)
         (Entity abstractId abstract)
         widget enctype
+
+-------------------------------------------------------
+-- Proof of concept slug versions
+-- Note to do a good job these should have used withConferenceCodeRedirect2 and 
+-- withConferenceCodeStrict2 an I should have changed existing rendering functions 
+-- (so they know ConferenceCode for form submission route)
+-------------------------------------------------------
+getConferenceAbstractPocR :: ConferenceCode -> AbstractId -> Handler Html
+getConferenceAbstractPocR code abstractId = 
+   withConferenceCodeRedirect (\c -> ConferenceAbstractPocR c abstractId) (flip getConferenceAbstractR abstractId) code
+
+postConferenceAbstractPocR :: ConferenceCode -> AbstractId -> Handler Html
+postConferenceAbstractPocR code abstractId = 
+   withConferenceCodeStrict (flip postConferenceAbstractR abstractId) code

--- a/src/Helpers/Handlers.hs
+++ b/src/Helpers/Handlers.hs
@@ -8,3 +8,34 @@ runDBOr404 dbma = do
   case maybeVal of
     Nothing -> notFound
     (Just val') -> return val'
+
+-- | Allows to use standard ID based semantics while exposing
+--   'ConferenceCode' based URL endpoint.  This assumes that the handler logic
+--   does not need to form any 'ConferenceCode' specific routes
+withConferenceCodeRedirect :: (ConferenceCode -> Route App) -- ^ use with something like SubmittedAbstractR from Routes.hs
+                            ->  (ConferenceId -> Handler a) -- ^ 'ConferenceId' based handler
+                            -> ConferenceCode               
+                            -> Handler a
+withConferenceCodeRedirect redirectTo handler conferenceCode = withConferenceCodeRedirect2 redirectTo (const handler) conferenceCode
+
+-- | in few places we need both 'ConferenceId' and 'ConferenceCode'. 
+--   'ConferenceId' is used for DB access, 
+--   'ConferenceCode' for using @Route App@ routes on the page.
+withConferenceCodeRedirect2 :: (ConferenceCode -> Route App) ->  (ConferenceCode -> ConferenceId -> Handler a) -> ConferenceCode -> Handler a
+withConferenceCodeRedirect2 redirectTo handler conferenceCode = do
+              confIdOrErr <- runDB $ resolveConferenceId conferenceCode
+              case confIdOrErr of
+                 Left SlugMissing -> notFound
+                 Left (SlugInactive activeCode) -> redirect (redirectTo activeCode)
+                 Right confId -> handler conferenceCode confId
+
+-- | This version does not redirect, used with POST endpoints which do not need it
+withConferenceCodeStrict :: (ConferenceId -> Handler a) -> ConferenceCode -> Handler a
+withConferenceCodeStrict handler conferenceCode = withConferenceCodeStrict2 (const handler) conferenceCode
+
+withConferenceCodeStrict2 :: (ConferenceCode -> ConferenceId -> Handler a) -> ConferenceCode -> Handler a
+withConferenceCodeStrict2 handler conferenceCode = do
+              confIdOrErr <- runDB $ resolveConferenceId conferenceCode
+              case confIdOrErr of
+                 Left _ -> notFound
+                 Right confId -> handler conferenceCode confId

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -108,7 +108,15 @@ Abstract sql=abstracts
   editedAbstract Markdown Maybe
   blocked Bool
   deriving Eq Show
+
+Slug sql=conference_slugs
+  conference ConferenceId
+  code ConferenceCode
+  UniqueSlugCode code
+  active Bool
+  deriving Eq Show
 |]
+
 
 abstractTitle :: Abstract -> Text
 abstractTitle abstract =

--- a/src/Model/Fixtures.hs
+++ b/src/Model/Fixtures.hs
@@ -99,6 +99,7 @@ makeConference accountId openingTime closingTime confName =
   createConferenceForAccount
     accountId confName
     "The coolest code conf"
+    (defaultConferenceCode confName)
     (Markdown [st|
 # You are submitting to the best conf
 
@@ -228,6 +229,8 @@ insertFixtures = do
 
   secondConfUniqueAbstract <-
     makeAbstract waddlesUserK secondConfSpamAbstractTypeK "Unique"
+
+  _ <- addInactiveConferenceCode chrisFirstConfK (makeConferenceCode "ChrisOldCode")
 
   let secondConfBlockedAbstract' =
         makeAbstract' waddlesUserK secondConfSpamAbstractTypeK "This was blocked"

--- a/src/Model/Types.hs
+++ b/src/Model/Types.hs
@@ -111,3 +111,18 @@ renderMarkdown (Markdown md) = do
   case htmlE of
     Left err -> throwIO (PandocRenderingFailed err md)
     (Right html) -> return html
+
+newtype ConferenceCode = 
+  ConferenceCode { unConferenceCode :: Text }
+  deriving (Eq, Show, Read, PathPiece, PersistField, PersistFieldSql)
+
+-- | So constructor can be treated as private
+makeConferenceCode :: Text -> ConferenceCode
+makeConferenceCode = ConferenceCode
+
+-- | To be used with conference name. Removes blanks from it to make URL piece cleaner.
+defaultConferenceCode :: Text -> ConferenceCode
+defaultConferenceCode = makeConferenceCode . filter ( /= ' ')
+
+displayConferenceCode :: ConferenceCode -> Text 
+displayConferenceCode = decodeUtf8 . urlEncode False . encodeUtf8 . unConferenceCode

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -35,4 +35,9 @@ mkYesodData "App" [parseRoutes|
 -- CFP submission
 /conference/#ConferenceId/cfp/submit                     SubmitAbstractR GET POST
 /conference/#ConferenceId/cfp/submitted                  SubmittedAbstractR GET
+
+-- Proof of concept slug based URLs
+/conference2/#ConferenceCode/cfp/submitted               SubmittedAbstractPocR GET
+/conference2/#ConferenceCode/abstract/#AbstractId        ConferenceAbstractPocR GET POST
+
 |]


### PR DESCRIPTION
This pull request has the required infrastructure for forming conference URLs with
human readable (admin definable) slugs.  Admins can change their mind and change the 
conferenceCode. If they do, the previous URLs will nicely redirect to the new code.

It is based on an older commit to avoid current 
'connPool forced in tempFoundation' issue and needs rebasing.

To finish this, I will need to modify most of the routes and handlers. I think, this would be best done when other pull requests are merged and there is no concurrent work happening.
I am concerned about hard to resolve merge conflicts if I make these changes now.

Chris, if this direction looks OK, I suggest that we schedule this work at some point so I can do the remaining changes (one evening).  

Thank you for your comments and review.  
No rush this proof of concept code should be not hard to rebase/merge.
